### PR TITLE
Make pending show as yellow

### DIFF
--- a/src/lib/client-report.html
+++ b/src/lib/client-report.html
@@ -29,8 +29,8 @@
             text-align: left;
             padding: 2px;
         }
-        .pending {
-            background: rgba(0, 0, 0, .2);
+        .pending, .undefined {
+            background: rgba(255, 255, 51, .6);
         }
         .passed {
             background: rgba(0, 192, 0, .5);


### PR DESCRIPTION
This is a common idiom in ruby land at least (rspec, cucumber, etc), so I borrowed from that because Cucumber.js output seems to do the same.  I also added an undefined class to the pending css block because that is how Cucumber marks them when it spits out the suggested step matchers on first run.

![screen shot 2014-05-15 at 1 11 32 pm](https://cloud.githubusercontent.com/assets/106/2987958/08694a56-dc54-11e3-97b9-3b57828cf6c2.png)
