### PR TITLE
Fix "check" error for apps using the Meteor "audit-argument-checks" package

### DIFF
--- a/main.js
+++ b/main.js
@@ -255,6 +255,9 @@ Velocity = {};
    * @private
    */
   function _checkRequired (requiredFields, target) {
+    // Check target to pass 'audit-argument-checks' requirement
+    check(target, Match.Any);
+
     _.each(requiredFields, function (name) {
       if (!target[name]) {
         throw new Error("Required field '" + name + "' is missing." +


### PR DESCRIPTION
Fixes "Did not check() all arguments during call to 'postResult' " error.
This is a requirement for apps using: http://docs.meteor.com/#auditargumentchecks
