### PR TITLE
Added env variable for disabling velocity directly.

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,7 +14,7 @@ Velocity = {};
 // Init
 //
 
-  if (process.env.NODE_ENV !== 'development' || process.env.IS_MIRROR) {
+  if (process.env.NODE_ENV !== 'development' || process.env.VELOCITY === '0' || process.env.IS_MIRROR) {
     DEBUG && console.log('Not adding velocity code');
     return;
   }


### PR DESCRIPTION
It's useful to disable velocity directly to speed up startup times rather than changing the `NODE_ENV`, which doesn't work for me with `NODE_ENV=dev meteor` - it still reverts to 'development'.
