### PR TITLE
Cleaning up the core before fixing #102

### DIFF
--- a/package.js
+++ b/package.js
@@ -39,11 +39,11 @@ Package.on_use(function (api) {
   api.export('VelocityLogs', ['client', 'server']);
   api.export('VelocityMirrors', ['client', 'server']);
 
-  api.add_files('main.js', 'server');
+  api.add_files('core.js', 'server');
   api.add_files(['lib/FileCopier.js'], 'server');
 
   // Assets
   api.add_files([
     'default-fixture.js'
-  ], 'server', {isAsset: true})
+  ], 'server', {isAsset: true});
 });


### PR DESCRIPTION
Renamed velocity/main.js to core.js, because :)

Removed any references / comments about frameworks. Velocity is an abstract runner and should be completely agnostic frameworks

Removed ParseXML() method. This is a report translation feature required by frameworks that have xUnit outputs, and should live in those frameworks or another package they can depend on

Post results has lots of optional properties that don’t need to be disabled. I've re-enabled them to make velocity compatible with more report types

Code tidy-ups to make jsHint happy

Applied Meteor formatting

Removed dead code
