### PR TITLE
Fix response being undefined

### DIFF
--- a/core.js
+++ b/core.js
@@ -745,6 +745,7 @@ Velocity = {};
           DEBUG && console.log('[velocity] retrying mirror at ', url);
           retry.retryLater(++tries, doGet);
         } else {
+          ex.response = ex.response || {};
           callback(ex.message, {statusCode: ex.response.statusCode});
         }
       }


### PR DESCRIPTION
Response object can be undefined if ECONNREFUSED. This will prevent exception being thrown.
