### PR TITLE
Adds API for setting and getting options.

### DIFF
--- a/collections.js
+++ b/collections.js
@@ -5,7 +5,8 @@
  VelocityTestReports: true,
  VelocityAggregateReports: true,
  VelocityLogs: true,
- VelocityMirrors: true
+ VelocityMirrors: true,
+ VelocityOptions: true
  */
 
 VelocityTestFiles = new Mongo.Collection('velocityTestFiles');
@@ -14,6 +15,7 @@ VelocityTestReports = new Mongo.Collection('velocityTestReports');
 VelocityAggregateReports = new Mongo.Collection('velocityAggregateReports');
 VelocityLogs = new Mongo.Collection('velocityLogs');
 VelocityMirrors = new Mongo.Collection('velocityMirrors');
+VelocityOptions = new Mongo.Collection('velocityOptions');
 (function () {
   'use strict';
 
@@ -36,6 +38,9 @@ VelocityMirrors = new Mongo.Collection('velocityMirrors');
     Meteor.publish('VelocityMirrors', function () {
       return VelocityMirrors.find({});
     });
+    Meteor.publish('VelocityOptions', function () {
+      return VelocityOptions.find({});
+    });
   }
 
   if (Meteor.isClient) {
@@ -45,6 +50,7 @@ VelocityMirrors = new Mongo.Collection('velocityMirrors');
     Meteor.subscribe('VelocityAggregateReports');
     Meteor.subscribe('VelocityLogs');
     Meteor.subscribe('VelocityMirrors');
+    Meteor.subscribe('VelocityOptions');
   }
 })();
 

--- a/core-shared.js
+++ b/core-shared.js
@@ -30,10 +30,34 @@ Velocity = Velocity || {};
       });
     };
 
+    if (Meteor.isServer) {
+      /**
+       * @method
+       * @see velocity/setOption
+       */
+      Velocity.setOption = function (name, value) {
+        Meteor.call('velocity/setOption', name, value);
+      };
+
+      /**
+       * @see velocity/setOptions
+       */
+      Velocity.setOptions = function (options) {
+        Meteor.call('velocity/setOptions', options);
+      };
+
+      /**
+       * @see velocity/getOption
+       */
+      Velocity.getOption = function (name) {
+        Meteor.call('velocity/getOption', name);
+      };
+    }
 
     Meteor.methods({
       /**
        * Set a option.
+       * @method velocity/setOption
        * @param name The name of the option.
        * @param value The value of the option.
        */
@@ -48,7 +72,23 @@ Velocity = Velocity || {};
       },
 
       /**
+       * Set multiple options.
+       * @method velocity/setOptions
+       * @param options Hash with options (name: value).
+       */
+      'velocity/setOptions': function (options) {
+        check(options, Object);
+
+        for (var name in options) {
+          if (options.hasOwnProperty(name)) {
+            Meteor.call('velocity/setOption', name, options[name]);
+          }
+        }
+      },
+
+      /**
        * Get a option
+       * @method velocity/getOption
        * @param name The name of the option.
        * @returns {*} The value of the option or null.
        */

--- a/core-shared.js
+++ b/core-shared.js
@@ -42,7 +42,7 @@ Velocity = Velocity || {};
         check(value, Match.Any);
 
         VelocityOptions.upsert(
-          {_id: name},
+          {name: name},
           {$set: {name: name, value: value}}
         );
       },

--- a/core-shared.js
+++ b/core-shared.js
@@ -11,7 +11,7 @@ Velocity = Velocity || {};
 //////////////////////////////////////////////////////////////////////
 // Public Methods
 //
-  
+
     /**
      * Mirrors can share the same codebase as the main process. This method will run provided code
      * inside a mirror only.
@@ -30,4 +30,33 @@ Velocity = Velocity || {};
       });
     };
 
+
+    Meteor.methods({
+      /**
+       * Set a option.
+       * @param name The name of the option.
+       * @param value The value of the option.
+       */
+      'velocity/setOption': function (name, value) {
+        check(name, String);
+        check(value, Match.Any);
+
+        VelocityOptions.upsert(
+          {_id: name},
+          {$set: {name: name, value: value}}
+        );
+      },
+
+      /**
+       * Get a option
+       * @param name The name of the option.
+       * @returns {*} The value of the option or null.
+       */
+      'velocity/getOption': function (name) {
+        check(name, String);
+
+        var option = VelocityOptions.findOne({name: name});
+        return option ? option.value : null;
+      }
+    });
 })();

--- a/package.js
+++ b/package.js
@@ -36,6 +36,7 @@ Package.on_use(function (api) {
   api.export('VelocityAggregateReports', BOTH);
   api.export('VelocityLogs', BOTH);
   api.export('VelocityMirrors', BOTH);
+  api.export('VelocityOptions', BOTH);
 
   api.add_files('core.js', SERVER);
   api.add_files('core-shared.js', BOTH);


### PR DESCRIPTION
I kept it simple.

Usage example in testing framework:

```javascript
var customIncludedPackages =
  process.env.JASMINE_PACKAGES_TO_INCLUDE_IN_UNIT_TESTS ||
  Meteor.call('velocity/getOption', 'JASMINE_PACKAGES_TO_INCLUDE_IN_UNIT_TESTS')
```

The user can set the option with:

```javascript
Meteor.call('velocity/setOption',
  'JASMINE_PACKAGES_TO_INCLUDE_IN_UNIT_TESTS',
  'some:package'
)
```