### PR TITLE
Added Meteor-Dredd to known Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Most of these frameworks have an example in the [velocity-examples](https://gith
 * [mike:mocha](https://github.com/mad-eye/meteor-mocha-web) - A Velocity version of mocha-web. Runs mocha tests in the Meteor context which is great for integration testing.
 * [xolvio:cucumber](https://github.com/xolvio/meteor-cucumber) - Use BDD Gherkin-syntax cucumber to test your app. Includes PhantomJS and Selenium as well as SauceLabs support. 
 * [rsbatech:robotframework](https://github.com/rjsmith/meteor-robotframework) - [Robot Framework](http://robotframework.org/) end to end test integration using Selenium and many other [test libraries](http://robotframework.org/#test-libraries)
+* [storeness:dredd](https://github.com/storeness/meteor-dredd) - [Dredd](https://github.com/apiaryio/dredd) HTTP API testing and validating of API Blueprint docs against your backend integration.
 
 A lot more information on these frameworks can be found on the [Velocity website](http://velocity.meteor.com/) and in their respective repositories.
 


### PR DESCRIPTION
I wrote an integration for the [Dredd — HTTP API Testing Framework](https://github.com/apiaryio/dredd) with Velocity. Maybe you want to display it on the known Framework list.