### PR TITLE
Fix issues with Webstorm debug mode.

### DIFF
--- a/src/methods/mirrors/mirror_request.js
+++ b/src/methods/mirrors/mirror_request.js
@@ -295,7 +295,8 @@ function _getEnvironmentVariables (options) {
     IS_MIRROR: true,
     HANDSHAKE: options.handshake,
     VELOCITY_MAIN_APP_PATH: Velocity.getAppPath(),
-    METEOR_SETTINGS: JSON.stringify(_.extend({}, Meteor.settings))
+    METEOR_SETTINGS: JSON.stringify(_.extend({}, Meteor.settings)),
+    NODE_OPTIONS: ""
   };
 
   if (options.env) {
@@ -304,14 +305,8 @@ function _getEnvironmentVariables (options) {
 
   _.defaults(env, process.env);
 
-  //if the debug variable is not set, remove the debug enviroment from the mirror
-  if (process.env.VELOCITY_DEBUG_MIRROR !== environment.FRAMEWORK &&
-    process.env.VELOCITY_DEBUG_MIRROR !== "webstorm") {
-    env.NODE_OPTIONS = null
-  }
-
   //if the debug variable is set to webstorm, allow a remote node debugging session to initiate without the break
-  else if(process.env.VELOCITY_DEBUG_MIRROR === "webstorm") {
+  if(process.env.VELOCITY_DEBUG_MIRROR === "webstorm") {
     env.NODE_OPTIONS = "--debug=5858"
   }
 

--- a/src/methods/mirrors/mirror_request.js
+++ b/src/methods/mirrors/mirror_request.js
@@ -168,6 +168,7 @@ function _startMirror (options) {
   if (
     process.env.VELOCITY_DEBUG_MIRROR &&
     process.env.VELOCITY_DEBUG_MIRROR === environment.FRAMEWORK &&
+    process.env.VELOCITY_DEBUG_MIRROR !==  "webstorm" &&
     !_.contains(options.args, '--debug-port')
   ) {
     var debugPort = '5858';
@@ -302,6 +303,17 @@ function _getEnvironmentVariables (options) {
   }
 
   _.defaults(env, process.env);
+
+  //if the debug variable is not set, remove the debug enviroment from the mirror
+  if (process.env.VELOCITY_DEBUG_MIRROR !== environment.FRAMEWORK &&
+    process.env.VELOCITY_DEBUG_MIRROR !== "webstorm") {
+    env.NODE_OPTIONS = null
+  }
+
+  //if the debug variable is set to webstorm, allow a remote node debugging session to initiate without the break
+  else if(process.env.VELOCITY_DEBUG_MIRROR === "webstorm") {
+    env.NODE_OPTIONS = "--debug=5858"
+  }
 
   return env;
 }


### PR DESCRIPTION
Short version - fixes this issue: https://groups.google.com/forum/#!topic/jasmine-js/__IYwOCyygE

Long version: Webstorm debug mode works by setting node debug mode and a port via the `NODE_OPTIONS` environment variable. These settings are propagated via the environment variable to the mirror, which then runs in debug mode on the same port as the server. This causes the mirror to hang, the server never handshakes, and the tests never run.

This modification changes two things. First, it sets the` NODE_OPTIONS` variable to an empty string by default. This allows the mirror to boot normally, while still being overriden if `VELOCITY_DEBUG_MIRROR=framework`.

Second, this adds a check to see if `VELOCITY_DEBUG_MIRROR="webstorm"`. If so, it disables the default mirror debug command, and uses the `NODE_OPTIONS` to run `debug` instead of meteor's default `debug-brk`. This allows the server and mirror to boot through and run tests in Webstorm's debug mode, while still allowing the user to connect to the mirror's debugger via node inspector in the browser or a node remote debug configuration in Webstorm.